### PR TITLE
Bundler CLI and quick-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Watch the first 15-20 minutes of the [September 1st Jupyter meeting video record
 
 ## Prerequisites
 
-* Jupyter Notebook 4.0.x running on Python 3.x or Python 2.7.x
+* Jupyter Notebook 4.0.x, 4.1.x, or 4.2.x running on Python 3.x or Python 2.7.x
 * Edge, Chrome, Firefox, or Safari
 
 Note: If you're running IPython Notebook 3.2.x, you can install the older 0.1.x version of the extension.
@@ -32,34 +32,32 @@ Note that both of these deployments tend to lag the latest stable release.
 
 ## Install It
 
-In Jupyter Notebook 4.2, you install and activate the extension using the `jupyter` command line like so:
+In Jupyter Notebook 4.2, you can install and activate all features of the extension in two commands like so:
 
 ```bash
-# install the python package
+# Install the python package
 pip install jupyter_cms
 
-# enable the server-side extension in the system prefix by default (e.g., conda env, venv)
-# or see jupyter serverextension enable --help for other options (e.g., --user)
-jupyter serverextension enable --py jupyter_cms --sys-prefix
-
-# install and enable the browser-side extension in the system prefix by default
-# or see jupyter nbextension enable --help for other options (e.g., --user)
-jupyter nbextension install --py jupyter_cms --sys-prefix
-jupyter nbextension enable --py jupyter_cms --sys-prefix
-
-# enable the notebook bundler
-jupyter bundler enable --py jupyter_cms --sys-prefix
+# Install all parts of the extension to the active conda / venv / python env
+# and enable all parts of it in the jupyter profile in that environment
+# See jupyter cms quick-setup --help for other options (e.g., --user)
+jupyter cms quick-setup --sys-prefix
+# The above command is equivalent to this sequence of commands:
+# jupyter serverextension enable --py jupyter_cms --sys-prefix
+# jupyter nbextension install --py jupyter_cms --sys-prefix
+# jupyter nbextension enable --py jupyter_cms --sys-prefix
+# jupyter bundler enable --py jupyter_cms --sys-prefix
 ```
 
 In Jupyter Notebook 4.1 and 4.0, you install and activate the extension like so:
 
 ```bash
-# install the python package
+# Install the python package
 pip install jupyter_cms
-# register the notebook frontend extensions into ~/.local/jupyter
-# see jupyter cms install --help for other options (e.g., --sys-prefix)
+# Register the notebook frontend extensions into ~/.local/jupyter
+# See jupyter cms install --help for other options (e.g., --sys-prefix)
 jupyter cms install --user --symlink --overwrite
-# enable the JS and server extensions in your ~/.jupyter
+# Enable the JS and server extensions in your ~/.jupyter
 jupyter cms activate
 ```
 
@@ -70,29 +68,53 @@ In either case, you will need to restart your notebook server if it was running 
 In Jupyter Notebook 4.2:
 
 ```bash
-# disable extensions and remove frontend files
-jupyter serverextension disable --py jupyter_cms --sys-prefix
-jupyter nbextension disable --py jupyter_cms --sys-prefix
-jupyter nbextension uninstall --py jupyter_cms --sys-prefix
-jupyter bundler disable --py jupyter_cms --sys-prefix
+# Remove all parts of the extension from the active conda / venv / python env
+# See jupyter cms quick-remove --help for other options (e.g., --user)
+jupyter cms quick-remove --sys-prefix
+# The above command is equivalent to this sequence of commands:
+# jupyter bundler disable --py jupyter_cms --sys-prefix
+# jupyter nbextension disable --py jupyter_cms --sys-prefix
+# jupyter nbextension uninstall --py jupyter_cms --sys-prefix
+# jupyter serverextension disable --py jupyter_cms --sys-prefix
 
-# remove the python package
+# Remove the python package
 pip uninstall jupyter_cms
 ```
 
 In Jupyter Notebook 4.0 and 4.1:
 
 ```bash
-# disable extensions, but no way to remove frontend assets in this version
+# Disable extensions, but no way to remove frontend assets in this version
 jupyter cms deactivate
 
-# remove the python package
+# Remove the python package
 pip uninstall jupyter_cms
 ```
 
 ## Writing Bundlers
 
-This extension supports the writing of *bundlers*, Python modules that may take a notebook, transform it (e.g,. using nbconvert), package the result, and either deploy it or download it. Bundlers should register themselves at install time using code like the following:
+This extension supports the writing of *bundlers*, Python modules that may take a notebook, transform it (e.g,. using nbconvert), package the result, and either deploy it or download it. 
+
+In Jupyter Notebook 4.2 and higher, a package should declare its metadata by implementing the `_jupyter_bundler_paths` function.
+
+```python
+def _jupyter_bundler_paths():
+    return [{
+            'name': 'notebook_associations_download',
+            'label': 'IPython Notebook bundle (.zip)',
+            'module_name': 'jupyter_cms.nb_bundler',
+            'group': 'download'
+    }]
+```
+
+The package can then instruct its users to enable and disable its bundlers via `jupyter bundler` command like so:
+
+```bash
+jupyter bundler enable --py my_bundlers
+jupyter bundler disable --py my_bundlers
+```
+
+In earlier versions of Jupyter Notebook, the package must implement its own CLI for enabling and disabling the bundler and update the user-specified config directly like so:
 
 ```python
 from notebook.services.config import ConfigManager

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ jupyter serverextension enable --py jupyter_cms --sys-prefix
 # or see jupyter nbextension enable --help for other options (e.g., --user)
 jupyter nbextension install --py jupyter_cms --sys-prefix
 jupyter nbextension enable --py jupyter_cms --sys-prefix
+
+# enable the notebook bundler
+jupyter bundler enable --py jupyter_cms --sys-prefix
 ```
 
 In Jupyter Notebook 4.1 and 4.0, you install and activate the extension like so:
@@ -71,6 +74,7 @@ In Jupyter Notebook 4.2:
 jupyter serverextension disable --py jupyter_cms --sys-prefix
 jupyter nbextension disable --py jupyter_cms --sys-prefix
 jupyter nbextension uninstall --py jupyter_cms --sys-prefix
+jupyter bundler disable --py jupyter_cms --sys-prefix
 
 # remove the python package
 pip uninstall jupyter_cms

--- a/jupyter_cms/__init__.py
+++ b/jupyter_cms/__init__.py
@@ -9,6 +9,15 @@ from jupyter_core.paths import jupyter_runtime_dir
 import os
 import json
 
+def _jupyter_bundler_paths():
+    '''API for notebook bundler installation on notebook 4.2'''
+    return [{
+            'name': 'notebook_associations_download',
+            'label': 'IPython Notebook bundle (.zip)',
+            'module_name': 'jupyter_cms.nb_bundler',
+            'group': 'download'
+    }]
+        
 def _jupyter_server_extension_paths():
     '''API for server extension installation on notebook 4.2'''
     return [{
@@ -70,7 +79,7 @@ def load_jupyter_server_extension(nb_app):
     '''
     Loads all extensions within this package.
     '''
-    nb_app.log.info('Loaded urth.cms')
+    nb_app.log.info('Loaded jupyter_cms')
     search.load_jupyter_server_extension(nb_app)
     uploads.load_jupyter_server_extension(nb_app)
     bundler.load_jupyter_server_extension(nb_app)

--- a/jupyter_cms/bundlerapp.py
+++ b/jupyter_cms/bundlerapp.py
@@ -1,0 +1,259 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import sys
+import os
+
+from notebook.nbextensions import (BaseNBExtensionApp, _get_config_dir)
+from ._version import __version__
+
+from traitlets.config.manager import BaseJSONConfigManager
+from traitlets.utils.importstring import import_item
+from traitlets import Bool
+
+BUNDLER_SECTION = "notebook"
+BUNDLER_SUBSECTION = "jupyter_cms_bundlers"
+
+def _get_bundler_metadata(module):
+    """Gets the list of bundlers associated with a Python package.
+    
+    Returns a tuple of (the module, [{
+        'name': 'unique name of the bundler',
+        'label': 'file menu item label for the bundler',
+        'module_name': 'dotted package/module name containing the bundler',
+        'group': 'download or deploy parent menu item'
+    }])
+    
+    Parameters
+    ----------
+
+    module : str
+        Importable Python module exposing the
+        magic-named `_jupyter_bundler_paths` function    
+    """
+    m = import_item(module)
+    if not hasattr(m, '_jupyter_bundler_paths'):
+        raise KeyError('The Python module {} does not contain a valid bundler'.format(module))
+    bundlers = m._jupyter_bundler_paths()
+    return m, bundlers
+
+def _set_bundler_state(name, label, module_name, group, state,
+                       user=True, sys_prefix=False, logger=None):
+    """Set whether a bundler is enabled or disabled.
+    
+    Returns True if the final state is the one requested.
+    
+    Parameters
+    ----------
+    name : string
+        Unique name of the bundler
+    label : string
+        Human-readable label for the bundler menu item in the notebook UI
+    module_name : string
+        Dotted module/package name containing the bundler
+    group : string
+        'download' or 'deploy' indicating the parent menu containing the label
+    state : bool
+        The state in which to leave the extension
+    user : bool [default: True]
+        Whether to update the user's .jupyter/nbconfig directory
+    sys_prefix : bool [default: False]
+        Whether to update the sys.prefix, i.e. environment. Will override
+        `user`.
+    logger : Jupyter logger [optional]
+        Logger instance to use
+    """
+    user = False if sys_prefix else user
+    config_dir = os.path.join(
+        _get_config_dir(user=user, sys_prefix=sys_prefix), 'nbconfig')
+    cm = BaseJSONConfigManager(config_dir=config_dir)
+    
+    if logger:
+        logger.info("{} {} bundler {}...".format(
+            "Enabling" if state else "Disabling",
+            name,
+            module_name
+        ))
+    
+    if state:
+        cm.update(BUNDLER_SECTION, {
+            BUNDLER_SUBSECTION: {
+                name: {
+                    "label": label,
+                    "module_name": module_name,
+                    "group" : group
+                }
+            }
+        })
+    else:
+        cm.update(BUNDLER_SECTION, {
+            BUNDLER_SUBSECTION: {
+                name: None
+            }
+        })
+
+    return (cm.get(BUNDLER_SECTION)
+              .get(BUNDLER_SUBSECTION, {})
+              .get(name) is not None) == state
+    
+
+def _set_bundler_state_python(state, module, user, sys_prefix, logger=None):
+    """Enables or disables bundlers defined in a Python package.
+    
+    Returns a list of whether the state was achieved for each bundler.
+    
+    Parameters
+    ----------
+    state : Bool
+        Whether the extensions should be enabled
+    module : str
+        Importable Python module exposing the
+        magic-named `_jupyter_bundler_paths` function
+    user : bool
+        Whether to enable in the user's nbconfig directory.
+    sys_prefix : bool
+        Enable/disable in the sys.prefix, i.e. environment
+    logger : Jupyter logger [optional]
+        Logger instance to use
+    """
+    m, bundlers = _get_bundler_metadata(module)
+    return [_set_bundler_state(name=bundler["name"],
+                               label=bundler["label"],
+                               module_name=bundler["module_name"],
+                               group=bundler["group"],
+                               state=state,
+                               user=user, sys_prefix=sys_prefix,
+                               logger=logger)
+            for bundler in bundlers]
+
+def enable_bundler_python(module, user=True, sys_prefix=False, logger=None):
+    """Enables bundlers defined in a Python package.
+    
+    Returns whether each bundle defined in the packaged was enabled or not.
+    
+    Parameters
+    ----------
+    module : str
+        Importable Python module exposing the
+        magic-named `_jupyter_bundler_paths` function
+    user : bool [default: True]
+        Whether to enable in the user's nbconfig directory.
+    sys_prefix : bool [default: False]
+        Whether to enable in the sys.prefix, i.e. environment. Will override
+        `user`
+    logger : Jupyter logger [optional]
+        Logger instance to use
+    """
+    return _set_bundler_state_python(True, module, user, sys_prefix,
+                                     logger=logger)
+    
+def disable_bundler_python(module, user=True, sys_prefix=False, logger=None):
+    """Disables bundlers defined in a Python package.
+    
+    Returns whether each bundle defined in the packaged was enabled or not.
+    
+    Parameters
+    ----------
+    module : str
+        Importable Python module exposing the
+        magic-named `_jupyter_bundler_paths` function
+    user : bool [default: True]
+        Whether to enable in the user's nbconfig directory.
+    sys_prefix : bool [default: False]
+        Whether to enable in the sys.prefix, i.e. environment. Will override
+        `user`
+    logger : Jupyter logger [optional]
+        Logger instance to use
+    """
+    return _set_bundler_state_python(False, module, user, sys_prefix,
+                                     logger=logger)
+
+class ToggleNBBundlerApp(BaseNBExtensionApp):
+    """A base class for apps that enable/disable bundlers"""
+    name = "jupyter bundler enable/disable"
+    version = __version__
+    description = "Enable/disable a bundler in configuration."
+
+    user = Bool(True, config=True, help="Apply the configuration only for the current user (default)")
+    
+    _toggle_value = None
+    
+    def _config_file_name_default(self):
+        """The default config file name."""
+        return 'jupyter_notebook_config'
+    
+    def toggle_bundler_python(self, module):
+        """Toggle some extensions in an importable Python module.
+
+        Returns a list of booleans indicating whether the state was changed as
+        requested.
+
+        Parameters
+        ----------
+        module : str
+            Importable Python module exposing the
+            magic-named `_jupyter_bundler_paths` function
+        """
+        toggle = (enable_bundler_python if self._toggle_value
+                  else disable_bundler_python)
+        return toggle(module,
+                      user=self.user,
+                      sys_prefix=self.sys_prefix,
+                      logger=self.log)
+
+    def start(self):
+        if not self.extra_args:
+            sys.exit('Please specify an nbextension/package to enable or disable')
+        elif len(self.extra_args) > 1:
+            sys.exit('Please specify one nbextension/package at a time')
+        if self.python:
+            self.toggle_bundler_python(self.extra_args[0])
+        else:
+            raise NotImplementedError('Cannot install bundlers from non-Python packages')            
+
+class EnableNBBundlerApp(ToggleNBBundlerApp):
+    """An App that enables bundlers"""
+    name = "jupyter bundler enable"
+    description = """
+    Enable a bundler in frontend configuration.
+    
+    Usage
+        jupyter bundler enable [--system|--sys-prefix]
+    """
+    _toggle_value = True
+    
+class DisableNBBundlerApp(ToggleNBBundlerApp):
+    """An App that disables bundlers"""
+    name = "jupyter bundler disable"
+    description = """
+    Disable a bundler in frontend configuration.
+    
+    Usage
+        jupyter bundler disable [--system|--sys-prefix]
+    """
+    _toggle_value = None
+
+class NBBundlerApp(BaseNBExtensionApp):
+    """Base jupyter bundler command entry point"""
+    name = "jupyter bundler"
+    version = __version__
+    description = "Work with Jupyter notebook bundlers"
+    examples = """
+jupyter bundler enable --py <packagename>     # enable all bundlers in a Python package
+jupyter bundler disable --py <packagename>    # disable all bundlers in a Python package
+"""
+
+    subcommands = dict(
+        enable=(EnableNBBundlerApp, "Enable a bundler"),
+        disable=(DisableNBBundlerApp, "Disable a bundler")
+    )
+
+    def start(self):
+        """Perform the App's functions as configured"""
+        super(NBBundlerApp, self).start()
+
+        # The above should have called a subcommand and raised NoStart; if we
+        # get here, it didn't, so we should self.log.info a message.
+        subcmds = ", ".join(sorted(self.subcommands))
+        sys.exit("Please supply at least one subcommand: %s" % subcmds)
+
+main = NBBundlerApp.launch_instance

--- a/jupyter_cms/bundlerapp.py
+++ b/jupyter_cms/bundlerapp.py
@@ -3,7 +3,12 @@
 import sys
 import os
 
-from notebook.nbextensions import (BaseNBExtensionApp, _get_config_dir)
+try:
+    from notebook.nbextensions import (BaseNBExtensionApp, _get_config_dir)
+except ImportError:
+    sys.exit("Aborted: {} requires notebook>=4.2".format(
+        os.path.basename(sys.argv[0])))
+    
 from ._version import __version__
 
 from traitlets.config.manager import BaseJSONConfigManager

--- a/jupyter_cms/extensionapp.py
+++ b/jupyter_cms/extensionapp.py
@@ -249,15 +249,15 @@ class ExtensionApp(Application):
     subcommands = dict(
         install=(
             ExtensionInstallApp,
-            "Install the extension (notebook<=4.1)"
+            "Install the extension (notebook<4.2)"
         ),
         activate=(
             ExtensionActivateApp,
-            "Activate the extension (notebook<=4.1)"
+            "Activate the extension (notebook<4.2)"
         ),
         deactivate=(
             ExtensionDeactivateApp,
-            "Deactivate the extension (notebook<=4.1)"
+            "Deactivate the extension (notebook<4.2)"
         ),
     )
     if _new_extensions:

--- a/jupyter_cms/extensionapp.py
+++ b/jupyter_cms/extensionapp.py
@@ -4,10 +4,20 @@ import errno
 import os.path
 import sys
 
+from ._version import __version__
+
 from jupyter_core.paths import jupyter_config_dir
 from notebook.services.config import ConfigManager
 from notebook.nbextensions import (InstallNBExtensionApp, EnableNBExtensionApp, 
     DisableNBExtensionApp, flags, aliases)
+
+try:
+    from notebook.nbextensions import BaseNBExtensionApp
+    _new_extensions = True
+except ImportError:
+    BaseNBExtensionApp = object
+    _new_extensions = False
+
 from traitlets import Unicode
 from traitlets.config.application import catch_config_error
 from traitlets.config.application import Application
@@ -180,6 +190,56 @@ class ExtensionDeactivateApp(DisableNBExtensionApp):
 
         self.log.info("Done. You may need to restart the Jupyter notebook server for changes to take effect.")
 
+class ExtensionQuickSetupApp(BaseNBExtensionApp):
+    """Installs and enables all parts of this extension"""
+    name = "jupyter cms quick-setup"
+    version = __version__
+    description = "Installs and enables all features of the jupyter_cms extension"
+
+    def start(self):
+        self.argv.extend(['--py', 'jupyter_cms'])
+        
+        from notebook import serverextensions
+        install = serverextensions.EnableServerExtensionApp()
+        install.initialize(self.argv)
+        install.start()
+        from notebook import nbextensions
+        install = nbextensions.InstallNBExtensionApp()
+        install.initialize(self.argv)
+        install.start()
+        enable = nbextensions.EnableNBExtensionApp()
+        enable.initialize(self.argv)
+        enable.start()
+        from jupyter_cms import bundlerapp
+        enable = bundlerapp.EnableNBBundlerApp()
+        enable.initialize(self.argv)
+        enable.start()
+
+class ExtensionQuickRemovalApp(BaseNBExtensionApp):
+    """Disables and uninstalls all parts of this extension"""
+    name = "jupyter cms quick-remove"
+    version = __version__
+    description = "Disables and removes all features of the jupyter_cms extension"
+
+    def start(self):
+        self.argv.extend(['--py', 'jupyter_cms'])
+        
+        from jupyter_cms import bundlerapp
+        enable = bundlerapp.DisableNBBundlerApp()
+        enable.initialize(self.argv)
+        enable.start()
+        from notebook import nbextensions
+        enable = nbextensions.DisableNBExtensionApp()
+        enable.initialize(self.argv)
+        enable.start()
+        install = nbextensions.UninstallNBExtensionApp()
+        install.initialize(self.argv)
+        install.start()
+        from notebook import serverextensions
+        install = serverextensions.DisableServerExtensionApp()
+        install.initialize(self.argv)
+        install.start()
+
 class ExtensionApp(Application):
     '''CLI for extension management.'''
     name = u'jupyter_cms extension'
@@ -189,17 +249,28 @@ class ExtensionApp(Application):
     subcommands = dict(
         install=(
             ExtensionInstallApp,
-            "Install the extension."
+            "Install the extension (notebook<=4.1)"
         ),
         activate=(
             ExtensionActivateApp,
-            "Activate the extension."
+            "Activate the extension (notebook<=4.1)"
         ),
         deactivate=(
             ExtensionDeactivateApp,
-            "Deactivate the extension."
-        )
+            "Deactivate the extension (notebook<=4.1)"
+        ),
     )
+    if _new_extensions:
+        subcommands.update({
+            "quick-setup": (
+                ExtensionQuickSetupApp,
+                "Install and enable everything in the package (notebook>=4.2)"
+            ),
+            "quick-remove": (
+                ExtensionQuickRemovalApp,
+                "Disable and uninstall everything in the package (notebook>=4.2)"
+            )
+        })
 
     def _classes_default(self):
         classes = super(ExtensionApp, self)._classes_default()

--- a/scripts/jupyter-bundler
+++ b/scripts/jupyter-bundler
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import jupyter_cms.bundlerapp
+
+if __name__ == '__main__':
+    jupyter_cms.bundlerapp.main()

--- a/setup.py
+++ b/setup.py
@@ -45,13 +45,14 @@ for more information.
     url='https://github.com/jupyter-incubator/contentmanagement',
     version=VERSION_NS['__version__'],
     license='BSD',
-    platforms=['Jupyter Notebook 4.0.x'],
+    platforms=['Jupyter Notebook 4.0.x', 'Jupyter Notebook 4.1.x', 'Jupyter Notebook 4.2.x'],
     packages=[
         'jupyter_cms'
     ],
     include_package_data=True,
     scripts=[
-        'scripts/jupyter-cms'
+        'scripts/jupyter-cms',
+        'scripts/jupyter-bundler'
     ],
     install_requires=install_requires,
     classifiers=[
@@ -71,7 +72,8 @@ if 'setuptools' in sys.modules:
     # setupstools turns entrypoint scripts into executables on windows
     setup_args['entry_points'] = {
         'console_scripts': [
-            'jupyter-cms = jupyter_cms.extensionapp:main'
+            'jupyter-cms = jupyter_cms.extensionapp:main',
+            'jupyter-bundler = jupyter_cms.bundlerapp:main'
         ]
     }
     # Don't bother installing the .py scripts if if we're using entrypoints


### PR DESCRIPTION
1. Implement a `jupyter bundler` subcommand so that dashboards_bundlers, kernel_gateway_bundlers, and others can easy install / uninstall their bundler implementations without needing a CLI of their own in Notebook 4.2 and up. Also makes the bundler aspects of this extension cleanly separable from the rest so that it might one day move to notebook proper.
2. Implement `jupyter cms quick-setup` to cut the four bash commands needed to setup all parts of the extension down to one. Implement `jupyter cms quick-remove` as the mirror option.

Continuation of #35 after I realized that the bundler install logic would no longer get run since `jupyter cms activate` was no longer run.
