### PR TITLE
Show only applicable options

### DIFF
--- a/jupyter_cms/extensionapp.py
+++ b/jupyter_cms/extensionapp.py
@@ -245,33 +245,36 @@ class ExtensionApp(Application):
     name = u'jupyter_cms extension'
     description = u'Utilities for managing the jupyter_cms extension'
     examples = ""
+    
+    subcommands = dict()
 
-    subcommands = dict(
-        install=(
-            ExtensionInstallApp,
-            "Install the extension (notebook<4.2)"
-        ),
-        activate=(
-            ExtensionActivateApp,
-            "Activate the extension (notebook<4.2)"
-        ),
-        deactivate=(
-            ExtensionDeactivateApp,
-            "Deactivate the extension (notebook<4.2)"
-        ),
-    )
     if _new_extensions:
         subcommands.update({
             "quick-setup": (
                 ExtensionQuickSetupApp,
-                "Install and enable everything in the package (notebook>=4.2)"
+                "Install and enable everything in the package"
             ),
             "quick-remove": (
                 ExtensionQuickRemovalApp,
-                "Disable and uninstall everything in the package (notebook>=4.2)"
+                "Disable and uninstall everything in the package"
             )
         })
-
+    else:
+        subcommands.update(dict(
+            install=(
+                ExtensionInstallApp,
+                "Install the extension"
+            ),
+            activate=(
+                ExtensionActivateApp,
+                "Activate the extension"
+            ),
+            deactivate=(
+                ExtensionDeactivateApp,
+                "Deactivate the extension"
+            ),
+        ))
+        
     def _classes_default(self):
         classes = super(ExtensionApp, self)._classes_default()
 


### PR DESCRIPTION
A bit more user friendliness: Don't show old install/activate options in notebook>=4.2

So in 4.2 we see:

```
(notebook-4.2)parente@aether ~/projects/jupyter/contentmanagement (subset-cli-opts●)$ jupyter cms
Utilities for managing the jupyter_cms extension

Subcommands
-----------

Subcommands are launched as `jupyter_cms extension cmd [args]`. For information
on using subcommand 'cmd', do: `jupyter_cms extension cmd -h`.

quick-setup
    Install and enable everything in the package
quick-remove
    Disable and uninstall everything in the package
```

and in versions prior to that:

```
(notebook-4.1)parente@aether ~/projects/jupyter/contentmanagement (subset-cli-opts)$ jupyter cms
Utilities for managing the jupyter_cms extension

Subcommands
-----------

Subcommands are launched as `jupyter_cms extension cmd [args]`. For information
on using subcommand 'cmd', do: `jupyter_cms extension cmd -h`.

activate
    Activate the extension
deactivate
    Deactivate the extension
install
    Install the extension
```
