### PR TITLE
Fix import without mywb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ dist/
 __pycache__/
 etc/notebooks/*
 .DS_Store
+.ipynb_checkpoints/

--- a/jupyter_cms/loader.py
+++ b/jupyter_cms/loader.py
@@ -238,15 +238,16 @@ class NotebookFinder(object):
         '''
         Find a notebook, given its fully qualified name and an optional path
         '''
-        # print '*** finding fullname:', fullname, 'path:', path
-        name = fullname.rsplit('.', 1)[-1]
-        path = [''] if path is None or not len(path) else path
-        fullpath = os.path.join(*path)
-
-        nb_path = os.path.join(fullpath, name + ".ipynb")
         loader = None
-        if os.path.isfile(nb_path):
-            loader = self.loader_cls(path, nb_path)
+        # print('*** finding fullname:', fullname, 'path:', path)
+        if fullname.startswith('mywb.'):
+            name = fullname.rsplit('.', 1)[-1]
+            path = [''] if path is None or not len(path) else path
+            fullpath = os.path.join(*path)
+
+            nb_path = os.path.join(fullpath, name + ".ipynb")
+            if os.path.isfile(nb_path):
+                loader = self.loader_cls(path, nb_path)
         return loader
 
 class NotebookPathFinder(object):

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -112,6 +112,21 @@ class TestNotebookFinder(unittest.TestCase):
             pass
         else:
             self.assertTrue(False, 'expected ImportError')
+            
+    def test_cwd_notebook(self):
+        '''Should not import a notebook in the cwd.'''
+        # switch to resources so that notebook are in the cwd
+        path = os.getcwd()
+        os.chdir(self.root)        
+        try:
+            import test_injectable as mod
+        except ImportError as e:
+            pass
+        else:
+            self.assertTrue(False, 'expected ImportError')
+        finally:
+            os.chdir(path)
+            
 
 class TestNotebookLoader(unittest.TestCase):
     '''Tests for loading notebooks within the loader root directory.'''


### PR DESCRIPTION
_.ipynb files in cwd are impotable without mywb._ prefix.
Fix this bug to require the prefix per the design. (It prevents
overlap with *.py files of the same name.)

Ref #25
